### PR TITLE
[feat] 新增 KaTeX 支持, 顶部或底部预览开关, esbuild 打包

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,2 @@
+src
+test

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,2 +1,4 @@
 src
 test
+
+dist/extension.js.map

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"onCommand:umath.preview.reloadMacros",
     "onCommand:umath.preview.closeAllPreview"
   ],
-  "main": "./src/extension.js",
+  "main": "./dist/extension.js",
   "contributes": {
     "commands": [
       {
@@ -107,6 +107,7 @@
     "yfzhao.hscopes-booster"
   ],
   "scripts": {
+    "vscode:prepublish": "esbuild ./src/extension.js --bundle --minify --platform=node --format=cjs --external:vscode --outfile=dist/extension.js",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test": "node ./test/runTest.js"
@@ -117,12 +118,13 @@
     "@types/node": "14.x",
     "@types/vscode": "^1.61.0",
     "@vscode/test-electron": "^2.0.3",
+    "esbuild": "^0.14.29",
     "eslint": "^8.6.0",
     "glob": "^7.2.0",
+    "katex": "^0.15.3",
+    "mathjax": "^3.2.0",
     "mocha": "^9.1.3"
   },
   "dependencies": {
-    "katex": "^0.15.3",
-    "mathjax": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -85,6 +85,15 @@
             "default": "bottom",
             "description": "Set math preview position."
           },
+          "umath.preview.renderer": {
+            "type": "string",
+            "enum": [
+              "mathjax",
+              "katex"
+            ],
+            "default": "mathjax",
+            "description": "Select math renderer."
+          },
           "umath.preview.macros": {
             "type": "array",
             "default": [],
@@ -113,6 +122,7 @@
     "mocha": "^9.1.3"
   },
   "dependencies": {
+    "katex": "^0.15.3",
     "mathjax": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "yfzhao.hscopes-booster"
   ],
   "scripts": {
-    "vscode:prepublish": "esbuild ./src/extension.js --bundle --minify --platform=node --format=cjs --external:vscode --outfile=dist/extension.js",
+    "vscode:prepublish": "esbuild ./src/extension.js --bundle --minify --inject:./src/MathJax-shim.js --define:global.MathJax=MathJax --platform=node --format=cjs --external:vscode --outfile=dist/extension.js",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test": "node ./test/runTest.js"
@@ -122,9 +122,7 @@
     "eslint": "^8.6.0",
     "glob": "^7.2.0",
     "katex": "^0.15.3",
-    "mathjax": "^3.2.0",
+    "mathjax-full": "^3.2.0",
     "mocha": "^9.1.3"
-  },
-  "dependencies": {
   }
 }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,9 @@
     "yfzhao.hscopes-booster"
   ],
   "scripts": {
-    "vscode:prepublish": "esbuild ./src/extension.js --bundle --minify --inject:./src/MathJax-shim.js --define:global.MathJax=MathJax --platform=node --format=cjs --external:vscode --outfile=dist/extension.js",
+    "vscode:prepublish": "npm run esbuild-base -- --minify",
+    "esbuild-base": "esbuild ./src/extension.js --bundle --inject:./src/MathJax-shim.js --define:global.MathJax=MathJax --platform=node --format=cjs --external:vscode --outfile=dist/extension.js",
+    "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test": "node ./test/runTest.js"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,15 @@
             "default": true,
             "description": "Show math preview."
           },
+          "umath.preview.position": {
+            "type": "string",
+            "enum": [
+              "top",
+              "bottom"
+            ],
+            "default": "bottom",
+            "description": "Set math preview position."
+          },
           "umath.preview.macros": {
             "type": "array",
             "default": [],

--- a/src/MathJax-shim.js
+++ b/src/MathJax-shim.js
@@ -6,4 +6,7 @@
 * See https://esbuild.docschina.org/api/#define
 */
 
-export let MathJax = {};
+export let MathJax = {
+    svg: { fontCache: 'local' },
+    startup: { typeset: false }
+};

--- a/src/MathJax-shim.js
+++ b/src/MathJax-shim.js
@@ -1,0 +1,9 @@
+/*
+* Inject `MathJax` global object.
+* See https://esbuild.docschina.org/api/#inject
+* 
+* Info: package.json need `esbuild --inject:./src/MathJax-shim.js --define:global.MathJax=MathJax`
+* See https://esbuild.docschina.org/api/#define
+*/
+
+export let MathJax = {};

--- a/src/math-preview.js
+++ b/src/math-preview.js
@@ -12,6 +12,7 @@ let macrosInfo = {};
 let macroConfig = vscode.workspace.getConfiguration().get("umath.preview.macros")
 let enablePreview = vscode.workspace.getConfiguration().get('umath.preview.enableMathPreview')
 let showPosition = vscode.workspace.getConfiguration().get('umath.preview.position')
+let renderer = vscode.workspace.getConfiguration().get('umath.preview.renderer')
 
 
 // handle MathJax error. Reload on error once.
@@ -44,6 +45,7 @@ function activate(context) {
         vscode.workspace.onDidChangeConfiguration(() => {
             macroConfig = vscode.workspace.getConfiguration().get("umath.preview.macros");
             showPosition = vscode.workspace.getConfiguration().get('umath.preview.position');
+            renderer = vscode.workspace.getConfiguration().get('umath.preview.renderer');
             enablePreview = vscode.workspace.getConfiguration().get('umath.preview.enableMathPreview')
             !enablePreview && clearPreview();
         })
@@ -118,7 +120,7 @@ function setPreview(document, position) {
 
 
 function pushPreview(mathExpression, isBlock, previewPosition) {
-    texRenderer.mathjax(mathExpression, isBlock)
+    texRenderer[renderer](mathExpression, isBlock)
         .then((svgString) => {
             // exclude error case
             if (svgString.indexOf("error") !== -1) return

--- a/src/texRenderer.js
+++ b/src/texRenderer.js
@@ -10,13 +10,13 @@ this.MathJax = {
     startup: { typeset: false }
 };
 
-require('mathjax/es5/startup');
-require('mathjax/es5/core');
-require('mathjax/es5/adaptors/liteDOM');
-require('mathjax/es5/input/mml');
-require('mathjax/es5/input/tex-full');
-require('mathjax/es5/output/svg');
-require('mathjax/es5/output/svg/fonts/tex');
+require('mathjax-full/components/src/startup/startup');
+require('mathjax-full/components/src/core/core');
+require('mathjax-full/components/src/adaptors/liteDOM/liteDOM');
+require('mathjax-full/components/src/input/mml/mml');
+require('mathjax-full/components/src/input/tex-full/tex-full');
+require('mathjax-full/components/src/output/svg/svg');
+require('mathjax-full/components/src/output/svg/fonts/tex/tex');
 
 MathJax.loader.preLoad(
     'core',

--- a/src/texRenderer.js
+++ b/src/texRenderer.js
@@ -4,12 +4,6 @@ const katex = require('katex');
 require('katex/contrib/mhchem');
 
 // Preload MathJax, See https://github.com/mathjax/MathJax-demos-node/tree/master/preload
-this.MathJax = {
-    options: { enableAssistiveMml: false },
-    svg: { fontCache: 'local' },
-    startup: { typeset: false }
-};
-
 require('mathjax-full/components/src/startup/startup');
 require('mathjax-full/components/src/core/core');
 require('mathjax-full/components/src/adaptors/liteDOM/liteDOM');

--- a/src/texRenderer.js
+++ b/src/texRenderer.js
@@ -1,5 +1,8 @@
 "use strict";
 
+const katex = require('katex');
+require('katex/contrib/mhchem');
+
 // Preload MathJax, See https://github.com/mathjax/MathJax-demos-node/tree/master/preload
 this.MathJax = {
     options: { enableAssistiveMml: false },
@@ -10,6 +13,7 @@ this.MathJax = {
 require('mathjax/es5/startup');
 require('mathjax/es5/core');
 require('mathjax/es5/adaptors/liteDOM');
+require('mathjax/es5/input/mml');
 require('mathjax/es5/input/tex-full');
 require('mathjax/es5/output/svg');
 require('mathjax/es5/output/svg/fonts/tex');
@@ -17,6 +21,7 @@ require('mathjax/es5/output/svg/fonts/tex');
 MathJax.loader.preLoad(
     'core',
     'adaptors/liteDOM',
+    'input/mml',
     'input/tex-full',
     'output/svg',
     'output/svg/fonts/tex'
@@ -37,6 +42,21 @@ const mathjaxRenderer = async (tex, isBlock = true) => {
     return svg;
 }
 
+const katexRenderer = async (tex, isBlock = true) => {
+    const mml = katex.renderToString(tex, {
+        displayMode: isBlock,
+        output: 'mathml',
+        throwOnError: false
+    }).slice(20, -7);
+
+    const node = await MathJax.mathml2svgPromise(mml, {display: isBlock});
+    const svg = MathJax.startup.adaptor.innerHTML(node);
+
+    MathJax.startup.document.clear();
+
+    return svg;
+}
 module.exports = {
-    mathjax: mathjaxRenderer
+    mathjax: mathjaxRenderer,
+    katex: katexRenderer
 }

--- a/src/texRenderer.js
+++ b/src/texRenderer.js
@@ -1,0 +1,42 @@
+"use strict";
+
+// Preload MathJax, See https://github.com/mathjax/MathJax-demos-node/tree/master/preload
+this.MathJax = {
+    options: { enableAssistiveMml: false },
+    svg: { fontCache: 'local' },
+    startup: { typeset: false }
+};
+
+require('mathjax/es5/startup');
+require('mathjax/es5/core');
+require('mathjax/es5/adaptors/liteDOM');
+require('mathjax/es5/input/tex-full');
+require('mathjax/es5/output/svg');
+require('mathjax/es5/output/svg/fonts/tex');
+
+MathJax.loader.preLoad(
+    'core',
+    'adaptors/liteDOM',
+    'input/tex-full',
+    'output/svg',
+    'output/svg/fonts/tex'
+    );
+MathJax.config.startup.ready();
+
+const mathjaxRenderer = async (tex, isBlock = true) => {
+    // enable render \\ as line break
+    if (isBlock) tex = `\\displaylines{${tex}}`;
+    
+    const node = await MathJax.tex2svgPromise(tex, {display: isBlock});
+    const svg = MathJax.startup.adaptor.innerHTML(node);
+
+    // clear && remove package from \requrie{}
+    MathJax.startup.document.clear();
+    MathJax.config.startup.ready();
+
+    return svg;
+}
+
+module.exports = {
+    mathjax: mathjaxRenderer
+}


### PR DESCRIPTION
感谢作者编写了这个好用的插件，我在使用插件时做出了一些改动，想将它们合并回上游，具体改动如下:

1. 重构了 MathJax 相关代码，使用[预加载](https://github.com/mathjax/MathJax-demos-node/tree/master/preload)， 不用每次都重新 `require`.
2. 添加了一个开关，可以选择在顶部或底部进行预览.
3. 添加 KaTeX 支持，并添加了 MathJax 或 KaTeX 的选择开关.
4. 使用 esbuild 进行打包，体积缩小到 1.8MiB, 如果排除 `image` 下的 gif 图片只有约 720KiB.

所有改动应当是和当前版本兼容的，~~不过也可能会有未知 BUG~~.
![Screenshot_20220401_234747](https://user-images.githubusercontent.com/78412663/161298125-8a33998f-97b7-45df-a6ce-512298f6048f.png)
![Screenshot_20220401_234833](https://user-images.githubusercontent.com/78412663/161298132-1b8db53d-986d-41f8-8516-7747f1b9d7dd.png)
